### PR TITLE
Fix decimal display

### DIFF
--- a/R/binomialdistribution.b.R
+++ b/R/binomialdistribution.b.R
@@ -135,27 +135,20 @@ BinomialDistributionClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         if(DistributionFunction=="TRUE"){
           if(DistributionFunctionType=="is"){
             DistributionResult <- dbinom(XValue, DP1, DP2)}
-          DistributionResult <- round(DistributionResult, digits = 3)
-          OutputLabel11 <- paste("P = ", DistributionResult, sep = "")}
+          OutputLabel11 <- DistributionResult}
         if(QuantileFunction=="TRUE"){
           if (QuantileFunctionType=="cumulative") {
-            QuantileResult <- round(QuantileResult, digits = 3)
-            OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")}
+            OutputLabel12 <- QuantileResult}
           if (QuantileFunctionType=="central") {
-            QuantileResult <- round(QuantileResult, digits = 3)
-            OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")
-            QuantileResult2 <- round(QuantileResult2, digits = 3)
-            OutputLabel22 <- paste("x2 = ", QuantileResult2, sep = "")}}
-        OutputSummary <- matrix(c(OutputLabel11, OutputLabel21, OutputLabel12, OutputLabel22), ncol=2, nrow=2)
+            OutputLabel12 <- QuantileResult
+            OutputLabel22 <- QuantileResult2}}
         # The Output-Matrix is written to the according Result-Frame
         Outputs <- self$results$Outputs
         Outputs$setRow(rowNo=1, values=list(
-          DistributionResultColumn=OutputSummary[1,1],
-          QuantileResultColumn=OutputSummary[1,2]))    
-        if((QuantileFunction=="TRUE")&(QuantileFunctionType=="central")){
-          Outputs$addRow(rowKey=2, values=list(
-            DistributionResultColumn=OutputSummary[2,1],
-            QuantileResultColumn=OutputSummary[2,2]))}
+          DistributionResultColumn=OutputLabel11,
+          QuantileResultColumn=OutputLabel12,
+          QuantileLowerResultColumn=OutputLabel12,
+          QuantileUpperResultColumn=OutputLabel22))
         
         
         ###### 1.3) Plot preparation ######

--- a/R/chi2distribution.b.R
+++ b/R/chi2distribution.b.R
@@ -115,17 +115,14 @@ Chi2DistributionClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         if(DistributionFunction=="TRUE"){
           if(DistributionFunctionType=="higher"){
             DistributionResult <- 1-DistributionResult}
-          DistributionResult <- round(DistributionResult, digits = 3)
-          OutputLabel11 <- paste("P = ", DistributionResult, sep = "")}
+          OutputLabel11 <- DistributionResult}
         if(QuantileFunction=="TRUE"){
-          QuantileResult <- round(QuantileResult, digits = 3)
-            OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")}
-        OutputSummary <- matrix(c(OutputLabel11, OutputLabel21, OutputLabel12, OutputLabel22), ncol=2, nrow=2)
-        # The Output-Matrix is written to the according Result-Frame
+            OutputLabel12 <- QuantileResult}
+           # The Output-Matrix is written to the according Result-Frame
         Outputs <- self$results$Outputs
         Outputs$setRow(rowNo=1, values=list(
-          DistributionResultColumn=OutputSummary[1,1],
-          QuantileResultColumn=OutputSummary[1,2]))    
+          DistributionResultColumn=OutputLabel11,
+          QuantileResultColumn=OutputLabel12))    
         
         
         ###### 1.3) Plot preparation ######

--- a/R/fdistribution.b.R
+++ b/R/fdistribution.b.R
@@ -127,17 +127,14 @@ FDistributionClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         if(DistributionFunction=="TRUE"){
           if(DistributionFunctionType=="higher"){
             DistributionResult <- 1-DistributionResult}
-          DistributionResult <- round(DistributionResult, digits = 3)
-          OutputLabel11 <- paste("P = ", DistributionResult, sep = "")}
+          OutputLabel11 <- DistributionResult}
         if(QuantileFunction=="TRUE"){
-          QuantileResult <- round(QuantileResult, digits = 3)
-            OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")}
-        OutputSummary <- matrix(c(OutputLabel11, OutputLabel21, OutputLabel12, OutputLabel22), ncol=2, nrow=2)
-        # The Output-Matrix is written to the according Result-Frame
+            OutputLabel12 <- pQuantileResult}
+         # The Output-Matrix is written to the according Result-Frame
         Outputs <- self$results$Outputs
         Outputs$setRow(rowNo=1, values=list(
-          DistributionResultColumn=OutputSummary[1,1],
-          QuantileResultColumn=OutputSummary[1,2]))    
+          DistributionResultColumn=OutputLabel11,
+          QuantileResultColumn=OutputLabel12))    
 
         
         ###### 1.3) Plot preparation ######

--- a/R/normaldistribution.b.R
+++ b/R/normaldistribution.b.R
@@ -127,27 +127,20 @@ NormaldistributionClass <- if (requireNamespace('jmvcore')) R6::R6Class(
       if(DistributionFunction=="TRUE"){
         if(DistributionFunctionType=="higher"){
           DistributionResult <- 1-DistributionResult}
-        DistributionResult <- round(DistributionResult, digits = 3)
-        OutputLabel11 <- paste("P = ", DistributionResult, sep = "")}
+        OutputLabel11 <- DistributionResult}
       if(QuantileFunction=="TRUE"){
         if (QuantileFunctionType=="cumulative") {
-          QuantileResult <- round(QuantileResult, digits = 3)
-          OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")}
+          OutputLabel12 <- QuantileResult}
         if (QuantileFunctionType=="central") {
-          QuantileResult <- round(QuantileResult, digits = 3)
-          OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")
-          QuantileResult2 <- round(QuantileResult2, digits = 3)
-          OutputLabel22 <- paste("x2 = ", QuantileResult2, sep = "")}}
-      OutputSummary <- matrix(c(OutputLabel11, OutputLabel21, OutputLabel12, OutputLabel22), ncol=2, nrow=2)
-      # The Output-Matrix is written to the according Result-Frame
+          OutputLabel12 <- QuantileResult
+          OutputLabel22 <- QuantileResult2}}
+     # The Output-Matrix is written to the according Result-Frame
       Outputs <- self$results$Outputs
       Outputs$setRow(rowNo=1, values=list(
-        DistributionResultColumn=OutputSummary[1,1],
-        QuantileResultColumn=OutputSummary[1,2]))    
-      if((QuantileFunction=="TRUE")&(QuantileFunctionType=="central")){
-        Outputs$addRow(rowKey=2, values=list(
-          DistributionResultColumn=OutputSummary[2,1],
-          QuantileResultColumn=OutputSummary[2,2]))}
+        DistributionResultColumn=OutputLabel11,
+        QuantileResultColumn=OutputLabel12,
+        QuantileLowerResultColumn=OutputLabel12,
+        QuantileUpperResultColumn=OutputLabel22))
     
 
       ###### 1.3) Plot preparation ######

--- a/R/tdistribution.b.R
+++ b/R/tdistribution.b.R
@@ -149,27 +149,20 @@ TDistributionClass <- if (requireNamespace('jmvcore')) R6::R6Class(
         if(DistributionFunction=="TRUE"){
           if(DistributionFunctionType=="higher"){
             DistributionResult <- 1-DistributionResult}
-          DistributionResult <- round(DistributionResult, digits = 3)
-          OutputLabel11 <- paste("P = ", DistributionResult, sep = "")}
+          OutputLabel11 <- DistributionResult}
         if(QuantileFunction=="TRUE"){
           if (QuantileFunctionType=="cumulative") {
-            QuantileResult <- round(QuantileResult, digits = 3)
-            OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")}
+            OutputLabel12 <- QuantileResult}
           if (QuantileFunctionType=="central") {
-            QuantileResult <- round(QuantileResult, digits = 3)
-            OutputLabel12 <- paste("x1 = ", QuantileResult, sep = "")
-            QuantileResult2 <- round(QuantileResult2, digits = 3)
-            OutputLabel22 <- paste("x2 = ", QuantileResult2, sep = "")}}
-        OutputSummary <- matrix(c(OutputLabel11, OutputLabel21, OutputLabel12, OutputLabel22), ncol=2, nrow=2)
+            OutputLabel12 <- QuantileResult
+            OutputLabel22 <- QuantileResult2}}
         # The Output-Matrix is written to the according Result-Frame
         Outputs <- self$results$Outputs
         Outputs$setRow(rowNo=1, values=list(
-          DistributionResultColumn=OutputSummary[1,1],
-          QuantileResultColumn=OutputSummary[1,2]))    
-        if((QuantileFunction=="TRUE")&(QuantileFunctionType=="central")){
-          Outputs$addRow(rowKey=2, values=list(
-            DistributionResultColumn=OutputSummary[2,1],
-            QuantileResultColumn=OutputSummary[2,2]))}
+          DistributionResultColumn=OutputLabel11,
+          QuantileResultColumn=OutputLabel12,
+          QuantileLowerResultColumn=OutputLabel12,
+          QuantileUpperResultColumn=OutputLabel22))
         
         
         ###### 1.3) Plot preparation ######

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -3,7 +3,7 @@ title: >-
   distrACTION - Quantiles and Probabilities of Continuous and Discrete
   Distributions
 name: distrACTION
-version: 1.0.0
+version: 1.0.1
 jms: '1.0'
 authors:
   - Michael Rihs
@@ -46,5 +46,7 @@ analyses:
     menuGroup: distrACTION
     menuTitle: Binomial Distribution
     menuSubgroup: Discrete distributions
+usesNative: true
+minApp: 1.0.8
 
 ...

--- a/jamovi/binomialdistribution.r.yaml
+++ b/jamovi/binomialdistribution.r.yaml
@@ -25,15 +25,31 @@ items:
       title: "Results"
       type: Table
       rows: 1
+      clearWith:  # <-- here
+        - group
+        - alt
+        - varEq
       columns:
         - name: DistributionResultColumn
           title: Probability
-          type: text
+          type: number
+          format: zto
           visible: (DistributionFunction)
         - name: QuantileResultColumn
-          title: Quantile(s)
-          type: text
-          visible: (QuantileFunction)
+          title: x1
+          type: integer
+          visible: (QuantileFunction && QuantileFunctionType=="cumulative")
+          superTitle: Quantile
+        - name: QuantileLowerResultColumn
+          title: x1
+          type: integer
+          visible: (QuantileFunction && QuantileFunctionType=="central")
+          superTitle: Quantiles
+        - name: QuantileUpperResultColumn
+          title: x2
+          type: integer
+          visible: (QuantileFunction && QuantileFunctionType=="central")
+          superTitle: Quantiles
           
     - name: plot
       title: ""

--- a/jamovi/chi2distribution.r.yaml
+++ b/jamovi/chi2distribution.r.yaml
@@ -25,14 +25,19 @@ items:
       title: "Results"
       type: Table
       rows: 1
+      clearWith:  # <-- here
+        - group
+        - alt
+        - varEq
       columns:
         - name: DistributionResultColumn
           title: Probability
-          type: text
+          type: number
+          format: zto
           visible: (DistributionFunction)
         - name: QuantileResultColumn
           title: Quantile
-          type: text
+          type: number
           visible: (QuantileFunction)
           
     - name: plot

--- a/jamovi/fdistribution.r.yaml
+++ b/jamovi/fdistribution.r.yaml
@@ -25,14 +25,18 @@ items:
       title: "Results"
       type: Table
       rows: 1
+      clearWith:  # <-- here
+        - group
+        - alt
+        - varEq
       columns:
         - name: DistributionResultColumn
           title: Probability
-          type: text
+          type: number
           visible: (DistributionFunction)
         - name: QuantileResultColumn
           title: Quantile
-          type: text
+          type: number
           visible: (QuantileFunction)
           
     - name: plot

--- a/jamovi/normaldistribution.r.yaml
+++ b/jamovi/normaldistribution.r.yaml
@@ -24,16 +24,33 @@ items:
     - name: Outputs
       title: "Results"
       type: Table
+      visible: (DistributionFunction || QuantileFunction)
       rows: 1
+      clearWith:  # <-- here
+        - group
+        - alt
+        - varEq
       columns:
         - name: DistributionResultColumn
           title: Probability
-          type: text
+          type: number
+          format: zto
           visible: (DistributionFunction)
         - name: QuantileResultColumn
-          title: Quantile(s)
-          type: text
-          visible: (QuantileFunction)
+          title: x1
+          type: number
+          visible: (QuantileFunction && QuantileFunctionType=="cumulative")
+          superTitle: Quantile
+        - name: QuantileLowerResultColumn
+          title: x1
+          type: number
+          visible: (QuantileFunction && QuantileFunctionType=="central")
+          superTitle: Quantiles
+        - name: QuantileUpperResultColumn
+          title: x2
+          type: number
+          visible: (QuantileFunction && QuantileFunctionType=="central")
+          superTitle: Quantiles
           
     - name: plot
       title: ""

--- a/jamovi/tdistribution.r.yaml
+++ b/jamovi/tdistribution.r.yaml
@@ -25,15 +25,31 @@ items:
       title: "Results"
       type: Table
       rows: 1
+      clearWith:  # <-- here
+        - group
+        - alt
+        - varEq
       columns:
-        - name: DistributionResultColumn
-          title: Probability
-          type: text
-          visible: (DistributionFunction)
-        - name: QuantileResultColumn
-          title: Quantile(s)
-          type: text
-          visible: (QuantileFunction)
+         - name: DistributionResultColumn
+           title: Probability
+           type: number
+           format: zto
+           visible: (DistributionFunction)
+         - name: QuantileResultColumn
+           title: x1
+           type: number
+           visible: (QuantileFunction && QuantileFunctionType=="cumulative")
+           superTitle: Quantile
+         - name: QuantileLowerResultColumn
+           title: x1
+           type: number
+           visible: (QuantileFunction && QuantileFunctionType=="central")
+           superTitle: Quantiles
+         - name: QuantileUpperResultColumn
+           title: x2
+           type: number
+           visible: (QuantileFunction && QuantileFunctionType=="central")
+           superTitle: Quantiles
           
     - name: plot
       title: ""


### PR DESCRIPTION
New display format to allow native decimals handling for the Binomial distribution
Switched layout from displaying "P=0.001" to just the value. Also formatted to better show single vs Upper/Lower Quantiles
Removed 3 decimal rounding from all values, and transferred values directly rather than through a matrix